### PR TITLE
GetStatus und Shelly.GetStatus zusammengeführt, JSON-String erweitert

### DIFF
--- a/ESP8266/pvakku-powermeter-emulator/komprimiert/1_SML_ShellyEmu_Simple.tas
+++ b/ESP8266/pvakku-powermeter-emulator/komprimiert/1_SML_ShellyEmu_Simple.tas
@@ -152,6 +152,7 @@ if (pwrforce>0) {
 =#getstat
 udp(2 header pwrstr)
 }
+}
 >W
 bu(save "gespeichert!" "Daten sofort speichern")
 Leistung (an PV Speicher){m}%0cpwr% W

--- a/ESP8266/pvakku-powermeter-emulator/komprimiert/1_SML_ShellyEmu_Simple.tas
+++ b/ESP8266/pvakku-powermeter-emulator/komprimiert/1_SML_ShellyEmu_Simple.tas
@@ -31,6 +31,7 @@ mstr2=""
 mstr3=""
 header=""
 once=0
+mode=0
 >B
 ->SetOption57 0
 ->sensor53 r
@@ -55,6 +56,7 @@ str=warg
 if (str!="") {
 res=ins(str "EM.GetStatus")
 if res>=0 {
+mode=0
 =#getstat
 tmp=sl(pwrstr)
 =#header
@@ -66,6 +68,7 @@ break
 }
 res=ins(str "Shelly.GetStatus")
 if res>=0 {
+mode=1
 =#getstat
 tmp=sl(mstr1)+sl(mstr2)+sl(mstr3)
 =#header
@@ -84,9 +87,11 @@ dp(0 2)
 pwrstr1="{\"id\":0,\"a_act_power\":"+s(c1p)+",\"b_act_power\":"+s(c2p)+",\"c_act_power\":"+s(c3p)+",\"total_act_power\":"+s(cpwr)+","
 pwrstr2="\"a_current\":"+s(c1c)+",\"b_current\":"+s(c2c)+",\"c_current\":"+s(c3c)+",\"a_voltage\":"+s(u)+",\"b_voltage\":"+s(u)+",\"c_voltage\":"+s(u)+"}"
 pwrstr=pwrstr1+pwrstr2
+if mode>0 {
 mstr1="{\"em:0\":"+pwrstr1+pwrstr2+","
 mstr2="\"emdata:0\":{\"id\":0,\"a_total_act_energy\":"+s(sml[2]*1000)+",\"a_total_act_ret_energy\":"+s(sml[3]*1000)+",\"b_total_act_energy\":0,\"b_total_act_ret_energy\":0,\"c_total_act_energy\":0,\"c_total_act_ret_energy\":0,"
 mstr3="\"total_act\":"+s(sml[2]*1000)+",\"total_act_ret\":"+s(sml[3]*1000)+"}}"
+}
 #header
 header="HTTP/1.1 200 OK\r\nServer: ShellyHTTP/1.0.0\r\nContent-Type: application/json\r\nContent-Length: "+s(0tmp)+"\r\nConnection: close\r\n\r\n"
 >F
@@ -95,12 +100,14 @@ if (str!="") {
 header="{\"id\":0,\"src\":\"shellypro3em-"+maca+"\",\"result\":"
 res=ins(str "EM.GetStatus")
 if (res>=0) {
+mode=0
 =#getstat
 udp(2 header pwrstr)
 break
 }
 res=ins(str "Shelly.GetStatus")
 if res>=0 {
+mode=1
 =#getstat
 udp(2 header mstr1 mstr2)
 udp(2 mstr3)

--- a/ESP8266/pvakku-powermeter-emulator/komprimiert/1_SML_ShellyEmu_Simple.tas
+++ b/ESP8266/pvakku-powermeter-emulator/komprimiert/1_SML_ShellyEmu_Simple.tas
@@ -20,8 +20,12 @@ c3p=0
 c1c=0
 c2c=0
 c3c=0
+u=230
 cpwr=0
 str=""
+pwrstr=""
+pwrstr1=""
+pwrstr2=""
 mstr1=""
 mstr2=""
 mstr3=""
@@ -52,18 +56,17 @@ if (str!="") {
 res=ins(str "EM.GetStatus")
 if res>=0 {
 =#getstat
-tmp=sl(mstr1)+sl(mstr2)
+tmp=sl(pwrstr)
 =#header
 wcs so(4)
 wcs %header%
-wcs %mstr1%
-wcs %mstr2%
+wcs %pwrstr%
 wcf
 break
 }
 res=ins(str "Shelly.GetStatus")
 if res>=0 {
-=#getshellystat
+=#getstat
 tmp=sl(mstr1)+sl(mstr2)+sl(mstr3)
 =#header
 wcs so(4)
@@ -78,11 +81,10 @@ print unknown rpc request: %str%
 }
 #getstat
 dp(0 2)
-mstr1="{\"id\":0,\"a_act_power\":"+s(c1p)+",\"b_act_power\":"+s(c2p)+","
-mstr2="\"c_act_power\":"+s(c3p)+",\"total_act_power\":"+s(cpwr)+"}}"
-#getshellystat
-dp(0 2)
-mstr1="{\"em:0\":{\"id\":0,\"a_act_power\":"+s(c1p)+",\"b_act_power\":"+s(c2p)+",\"c_act_power\":"+s(c3p)+",\"total_act_power\":"+s(cpwr)+"},"
+pwrstr1="{\"id\":0,\"a_act_power\":"+s(c1p)+",\"b_act_power\":"+s(c2p)+",\"c_act_power\":"+s(c3p)+",\"total_act_power\":"+s(cpwr)+","
+pwrstr2="\"a_current\":"+s(c1c)+",\"b_current\":"+s(c2c)+",\"c_current\":"+s(c3c)+",\"a_voltage\":"+s(u)+",\"b_voltage\":"+s(u)+",\"c_voltage\":"+s(u)+"}"
+pwrstr=pwrstr1+pwrstr2
+mstr1="{\"em:0\":"+pwrstr1+pwrstr2+","
 mstr2="\"emdata:0\":{\"id\":0,\"a_total_act_energy\":"+s(sml[2]*1000)+",\"a_total_act_ret_energy\":"+s(sml[3]*1000)+",\"b_total_act_energy\":0,\"b_total_act_ret_energy\":0,\"c_total_act_energy\":0,\"c_total_act_ret_energy\":0,"
 mstr3="\"total_act\":"+s(sml[2]*1000)+",\"total_act_ret\":"+s(sml[3]*1000)+"}}"
 #header
@@ -94,13 +96,12 @@ header="{\"id\":0,\"src\":\"shellypro3em-"+maca+"\",\"result\":"
 res=ins(str "EM.GetStatus")
 if (res>=0) {
 =#getstat
-udp(2 header mstr1 mstr2)
+udp(2 header pwrstr)
 break
 }
 res=ins(str "Shelly.GetStatus")
 if res>=0 {
-=#getshellystat
-mstr3+="}"
+=#getstat
 udp(2 header mstr1 mstr2)
 udp(2 mstr3)
 break
@@ -149,11 +150,11 @@ c1p=cpwr
 c1c=c1p/230
 if (pwrforce>0) {
 =#getstat
-udp(2 header mstr1 mstr2)
+udp(2 header pwrstr)
 }
 >W
 bu(save "gespeichert!" "Daten sofort speichern")
-Leistung (an Marstek Akku){m}%0cpwr% W
+Leistung (an PV Speicher){m}%0cpwr% W
 Tagesverbrauch{m}%2(sml[2]-dval)% kWh
 Monatsverbrauch{m}%2(sml[2]-mval)% kWh
 Jahresverbrauch{m}%2(sml[2]-yval)% kWh


### PR DESCRIPTION
- getstatus und getshellystatus zusammengelegt
- neuen JSON-String (pwrstr) eingeführt, um zusätzliche Werte integrieren zu können
- String wegen Script-Längenlimit in mehrere Teile aufgeteilt
- Webinterface-Text verallgemeinert („PV Speicher“ statt „Marstek Akku“)
- kleinere Schönheitsfehler wie Klammerfehler berichtigt ;)