### PR TITLE
Update Logarex LK13BE.tas add Total und Energy for easy use in HA

### DIFF
--- a/script-list-menu/meters/Logarex/Logarex LK13BE.tas
+++ b/script-list-menu/meters/Logarex/Logarex LK13BE.tas
@@ -1,8 +1,8 @@
 >M 1
 +1,%0rxpin%,s,0,9600,LK13BE,%0txpin%
 1,77070100100700ff@1,Leistung,W,Power,0
-1,77070100010800ff@1000,Verbrauch,kWh,E_in,3
-1,77070100020800ff@1000,Einspeisung,kWh,E_out,3
+1,77070100010800ff@1000,Verbrauch,kWh,Total,3
+1,77070100020800ff@1000,Einspeisung,kWh,Energy,3
 1,=h--
 1,77070100240700ff@1,Leistung_L1,W,power_L1,0
 1,77070100380700ff@1,Leistung_L2,W,power_L2,0


### PR DESCRIPTION
werden Verbrauch und Einspeisung mit Total und Energy an HA gesendet, dann landet total_increase und kWh automatisch im HA und man spart es sich das Template nochmal anzupassen.
Habe ich bei mir im HA und mit dem Bitshake in 2 Haushalten am laufen.